### PR TITLE
Hide button commands and remove choose hardware command

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,6 @@
         "category": "%makecode.category.title%"
       },
       {
-        "command": "makecode.choosehw",
-        "title": "%makecode.choosehw.title%",
-        "category": "%makecode.category.title%"
-      },
-      {
         "command": "makecode.install",
         "title": "%makecode.install.title%",
         "category": "%makecode.category.title%"
@@ -252,6 +247,36 @@
           "command": "makecode.deleteAsset",
           "when": "view == imageExplorer || view == tilemapExplorer || view == animationExplorer || view == songExplorer",
           "group": "inline"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "makecode.duplicateAsset",
+          "when": "false"
+        },
+        {
+          "command": "makecode.deleteAsset",
+          "when": "false"
+        },
+        {
+          "command": "makecode.createAnimation",
+          "when": "false"
+        },
+        {
+          "command": "makecode.createImage",
+          "when": "false"
+        },
+        {
+          "command": "makecode.createSong",
+          "when": "false"
+        },
+        {
+          "command": "makecode.createTile",
+          "when": "false"
+        },
+        {
+          "command": "makecode.createTilemap",
+          "when": "false"
         }
       ]
     }

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -49,7 +49,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     addCmd("makecode.build", buildCommand);
     addCmd("makecode.simulate", () => simulateCommand(context));
-    addCmd("makecode.choosehw", choosehwCommand);
     addCmd("makecode.create", createCommand);
     addCmd("makecode.install", installCommand);
     addCmd("makecode.clean", cleanCommand);
@@ -337,10 +336,6 @@ async function refreshAssetsCommand(justFireEvent: boolean) {
     else {
         await syncJResAsync();
     }
-}
-
-async function choosehwCommand() {
-    console.log("Choose hardware command");
 }
 
 interface HardwareQuickpick extends vscode.QuickPickItem {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-vscode-web/issues/28
Fixes https://github.com/microsoft/pxt-vscode-web/issues/27
Fixes https://github.com/microsoft/pxt-vscode-web/issues/15
Fixes https://github.com/microsoft/pxt-vscode-web/issues/13

This hides all of the internal commands that are used for UI buttons but not meant to be invoked from the command palette. 

As a bonus, also gets rid of the "choose hardware" command