### PR TITLE
Clarify error messages and refresh vscode ui after most commands

### DIFF
--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -188,6 +188,8 @@ async function buildCommand() {
         if (result.diagnostics.length) {
             reportBuildErrors(result);
         }
+
+        await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     });
 }
 
@@ -205,6 +207,9 @@ export async function installCommand() {
         cancellable: false
     }, async progress => {
         await installDependenciesAsync(workspace);
+
+        await vscode.commands.executeCommand("makecode.refreshAssets");
+        await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     });
 }
 
@@ -222,6 +227,7 @@ async function cleanCommand() {
         cancellable: false
     }, async progress => {
         await cleanProjectFolderAsync(workspace);
+        await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     });
 }
 
@@ -276,6 +282,9 @@ export async function importUrlCommand(url?: string, useWorkspace?: vscode.Works
         catch (e) {
             showError(vscode.l10n.t("Unable to install project dependencies"));
         }
+
+        await vscode.commands.executeCommand("makecode.refreshAssets");
+        await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     });
 }
 
@@ -389,6 +398,9 @@ async function createCommand()  {
         catch (e) {
             showError(vscode.l10n.t("Unable to install project dependencies"));
         }
+
+        await vscode.commands.executeCommand("makecode.refreshAssets");
+        await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     });
 }
 
@@ -488,6 +500,9 @@ async function removeDependencyCommandAsync() {
         }
 
         await installDependenciesAsync(workspace);
+
+        await vscode.commands.executeCommand("makecode.refreshAssets");
+        await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     })
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-vscode-web/issues/29
Fixes https://github.com/microsoft/pxt-vscode-web/issues/22
And fixes part of https://github.com/microsoft/pxt-vscode-web/issues/26

Two main changes in this PR:

1. Clarified the error messages around workspaces to be more actionable
2. Added code to force the asset explorer and file list to refresh after most commands

This should deal with the part of #26 where it doesn't appear to do anything; the built folder will now be visible without a refresh at least!