### PR TITLE
Use vfs for importing projects

### DIFF
--- a/src/web/assetEditor.ts
+++ b/src/web/assetEditor.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { readFileAsync, writeFileAsync } from "./host";
+import { activeWorkspace, findFilesAsync, readFileAsync, writeFileAsync } from "./host";
 import { syncJResAsync } from "./jres";
 import { readTextFileAsync } from "./util";
 
@@ -225,7 +225,7 @@ async function getAssetEditorHtmlAsync(webview: vscode.Webview) {
 }
 
 async function readProjectJResAsync() {
-    const files = await vscode.workspace.findFiles("**/*.jres");
+    const files = await findFilesAsync("jres", activeWorkspace().uri, false);
     const fileSystem: {[index: string]: string} = {};
 
     for (const file of files) {

--- a/src/web/jres.ts
+++ b/src/web/jres.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { activeWorkspace, findFilesAsync } from "./host";
 import { readTextFileAsync } from "./util";
 
 
@@ -114,7 +115,7 @@ export async function deleteAssetAsync(node: JResTreeNode) {
 
 async function readProjectJResAsync() {
     const nodes: JResTreeNode[] = [];
-    const files = await vscode.workspace.findFiles("**/*.jres");
+    const files = await findFilesAsync("jres", activeWorkspace().uri, false);
 
     for (const file of files) {
         if (file.fsPath.indexOf("pxt_modules") !== -1 || file.fsPath.indexOf("node_modules") !== -1) {

--- a/src/web/vfs.ts
+++ b/src/web/vfs.ts
@@ -96,7 +96,7 @@ export class VFS implements vscode.FileSystemProvider {
                     await this.initializePromises[parts[0]];
                 }
             }
-            else if (/^(?:S?\d{4}[\d\-]+|_[a-zA-Z0-9]{10,}\.code-workspace)$/.test(parts[0])) {
+            else if (/^(?:(?:S?\d{4}[\d\-]+|_[a-zA-Z0-9]{10,})\.code-workspace)$/.test(parts[0])) {
                 if (!this.initializedDirs[parts[0]]) {
                     if (!this.initializePromises[parts[0]]) {
                         this.initializePromises[parts[0]] = this.initializeWorkspace(parts[0])


### PR DESCRIPTION
This changes the import url command do that it imports projects into the vfs if there is a URL argument provided and no workspace open. Should be no change for the normal experience, but this does make it so that the /makecode/projectid route works!

I had to implement my own `findFiles` function because vscode has a lovely bug where using that function in a virtual file system causes the promise to never return. I'll file an issue, but it was easy enough to code a replacement for now (spent almost an entire day trying to find this issue tho)