### PR TITLE
filter out nullish deps from dep search

### DIFF
--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -487,7 +487,7 @@ async function addDependencyCommandAsync() {
                 qp.items = [
                     userEnteredSuggestion,
                     ...defaultPreferredExtensions
-                ];
+                ].filter(el => !!el.id);
             }
         });
         qp.onDidAccept(() => {


### PR DESCRIPTION
Remove nullish entries from dependency search suggestions (so if you e.g. type something then backspace it away you don't up with an empty suggestion at the top of the list.)