### PR TITLE
Trim length of description & revise so it shows up better in extension search

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pxt-vscode-web",
   "publisher": "ms-edu",
   "displayName": "Microsoft MakeCode Arcade",
-  "description": "Learn code and make games. Create retro arcade style video games, art, and music inside VS Code.",
+  "description": "Make games and learn code. Create retro arcade style video games, art, and music inside VS Code.",
   "version": "0.0.7",
   "engines": {
     "vscode": "^1.74.0"


### PR DESCRIPTION
There are two 'main' places this shows up inside vs code where size is a problem -- the side bar view search pane, which with the default view we show up pretty well in as is (depending on window size it looks like you typically get about 25-35 characters): 

![image](https://user-images.githubusercontent.com/5615930/219453316-593ab21b-e5d4-4523-8b2f-bd08edf470fc.png)

and then the header on the extension preview that pops up when you select one to learn more about it (which very heavily depends on screen resolution -- at default resolution / 1920/1080 vscode.dev you get about 160 characters, but my typical vscode window is down to about 80-120)
![image](https://user-images.githubusercontent.com/5615930/219454012-c52c235f-4f23-4f3a-9608-6c8603aceb20.png)

This trims it to 96 chars for the full size (and remains at 26 for the first sentence). Also swapped it to sentence casing instead of title case to match what I saw in other popular extensions, and I tried to emphasize that the music / art creation happens inside vscode itself (/ that it's not just importing assets)

close https://github.com/microsoft/pxt-vscode-web/issues/44