### PR TITLE
hide full screen button in sim view

### DIFF
--- a/src/web/simulator.ts
+++ b/src/web/simulator.ts
@@ -141,6 +141,15 @@ export class SimulatorSerializer implements vscode.WebviewPanelSerializer {
     }
 }
 
+const vscodeExtensionExtraLoaderJs = `
+window.addEventListener("DOMContentLoaded", () => {
+    const fs = document.getElementById("fullscreen");
+    if (fs) {
+        fs.remove();
+    }
+});
+`;
+
 
 async function getSimHtmlAsync() {
     const index = simloaderFiles["index.html"];
@@ -161,6 +170,9 @@ async function getSimHtmlAsync() {
             return `
             <script type="text/javascript">
                 ${loaderJs}
+            </script>
+            <script type="text/javascript">
+                ${vscodeExtensionExtraLoaderJs}
             </script>
             `;
         }


### PR DESCRIPTION
This felt like a bit better of a place to fix than adjusting in pxt-mkc; that's already doing it's due diligence with feature detection here https://github.com/microsoft/pxt-mkc/blob/master/packages/makecode-core/simloader/loader.ts#L267, it's just that we have the api but the request is denied due to iframe settings :)

Could move this over to a separate folder similar to the setup with the simloader folder in pxt-mkc but there probably won't be too many pxt-vscode-web specific customizations for the time being so it felt like it would be a bit much -- maybe just move to a file in /resources if we don't want it as just a template string

fix https://github.com/microsoft/pxt-vscode-web/issues/59