### PR TITLE
remove the prompt since it's moving towards auto save

### DIFF
--- a/resources/assetMessaging.js
+++ b/resources/assetMessaging.js
@@ -1,6 +1,5 @@
 (function () {
     let frame;
-    let toastContainer;
     let vscode = acquireVsCodeApi();
 
     window.addEventListener("message", function (m) {
@@ -17,27 +16,9 @@
             }
         } else {
             vscode.postMessage(m.data);
-            if (m.data.type === "save") {
-                showToast("Project assets saved!", 3000);
-            }
         }
     });
     document.addEventListener("DOMContentLoaded", function (event) {
         frame = document.getElementById("asset-editor-frame");
-        toastContainer = document.getElementById("toast-container");
     });
-
-    function showToast(message, millis) {
-        clearToastContainer();
-        const toastDiv = document.createElement("div");
-        toastContainer.appendChild(toastDiv);
-
-        toastDiv.textContent = message;
-
-        setTimeout(() => clearToastContainer(), millis)
-    }
-
-    function clearToastContainer() {
-        while (toastContainer.firstChild) toastContainer.firstChild.remove();
-    }
 }())

--- a/resources/assetframe.html
+++ b/resources/assetframe.html
@@ -15,9 +15,6 @@
             sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0">
         </iframe>
     </div>
-    <div class="asset-editor-toast" id="toast-container">
-
-    </div>
 </body>
 
 </html>


### PR DESCRIPTION
this along with https://github.com/microsoft/pxt/pull/9394 would close https://github.com/microsoft/pxt-vscode-web/issues/55

Remove the little save toast since we probably don't want that flashing every time the user makes an edit.

Leaves one minor question on what the done button should do / should it even exist if we're always auto saving? I guess we could make it actually close the webview after the save is complete if the user presses it (to match more closely with how webapp works) but that doesn't feel quite right to me.