### PR TITLE
add debounce to build watcher

### DIFF
--- a/src/web/util.ts
+++ b/src/web/util.ts
@@ -27,6 +27,27 @@ export function throttle(func: (...args: any[]) => any, wait: number, immediate?
     };
 }
 
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+export function debounce(func: (...args: any[]) => any, wait: number, immediate?: boolean): any {
+    let timeout: any;
+    return function (this: any) {
+        const context = this
+        const args = arguments;
+        const later = function () {
+            timeout = null;
+            if (!immediate) func.apply(context, args as any);
+        };
+        const callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args as any);
+        return timeout;
+    };
+}
+
 export function delay(ms: number) {
     return new Promise<void>(resolve => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-makecode/issues/83 (I believe? Or did you mean to keep this watcher as a throttle & only debounce the sending of build results to sim, I suppose either way should be similar for the most part?)

We're gonna have to play with this debounce for a while till we find something that feels right as a default I think. Maybe we could do something cute where we have a debounce that runs immediately the first time but ends up as trailing with delay if called again by exposing a .isDebouncing property on the returned function from debounce, or just add a "if last build was more than 10 seconds ago don't debounce" type of logic

I stole the wording of the description from the only default setting I saw that pops up when you search "debounce":

![image](https://user-images.githubusercontent.com/5615930/220991049-54fb295c-6d6d-41db-a551-7f13ff9db551.png)

if you wanna test this out you'll probably want to throw these two settings in `.vscode/settings.json` (and make sure to clear out `files.autoSaveDelay` afterwards):

```json
    "files.autoSave": "afterDelay",
    "files.autoSaveDelay": 1,
```