### PR TITLE
don't double install dependencies for new project

### DIFF
--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -296,17 +296,6 @@ export async function importUrlCommand(url?: string, useWorkspace?: vscode.Works
             return;
         }
 
-        progress.report({
-            message: vscode.l10n.t("Installing dependencies...")
-        });
-
-        try {
-            await installDependenciesAsync(workspace!);
-        }
-        catch (e) {
-            showError(vscode.l10n.t("Unable to install project dependencies"));
-        }
-
         await vscode.commands.executeCommand("makecode.refreshAssets");
         await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     });
@@ -426,17 +415,6 @@ async function createCommand()  {
         catch (e) {
             showError(vscode.l10n.t("Unable to create project"));
             return;
-        }
-
-        progress.report({
-            message: vscode.l10n.t("Installing dependencies...")
-        });
-
-        try {
-            await installDependenciesAsync(workspace);
-        }
-        catch (e) {
-            showError(vscode.l10n.t("Unable to install project dependencies"));
         }
 
         await vscode.commands.executeCommand("makecode.refreshAssets");


### PR DESCRIPTION
the 'new project' command in pxt-mkc [already installs deps](https://github.com/microsoft/pxt-mkc/blob/5a56f239ee653bd750dff24fe53143df05767586/packages/makecode-core/src/commands.ts#L568) so this was re-saving everything, making it take twice as long (which doesn't take long on desktop, just when fs operations are slow)