### PR TITLE
fix gallery on desktop

### DIFF
--- a/src/web/host.ts
+++ b/src/web/host.ts
@@ -194,12 +194,6 @@ export function activeWorkspace() {
 }
 
 export async function findFilesAsync(extension: string, root: vscode.Uri, matchWholeName: boolean, maxDepth = 5) {
-    // For some reason, vscode.workspace.findFiles doesn't work on virtual filesystems. If we aren't on a
-    // virtual file system, we can still use it.
-    if (root.scheme === "file") {
-        return await vscode.workspace.findFiles("**/" + (matchWholeName ? extension : `*.${extension}`))
-    }
-
     if (maxDepth === 0) return [];
 
     const files = await vscode.workspace.fs.readDirectory(root);


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-makecode/issues/97

I didn't look into what was actually failing to find the files as I'd personally prefer to just use the one code path for both vfs and normal fs, especially since findFiles has the downside of searching all open workspaces instead of being limited to one folder (which we could work around, but if it's already implemented / working for vfs I'm not sure I see a reason to). If you want though I'll see what was actually going wrong though