### PR TITLE
clear buildwatcher errors on sim close

### DIFF
--- a/src/web/buildWatcher.ts
+++ b/src/web/buildWatcher.ts
@@ -67,6 +67,10 @@ export class BuildWatcher {
     }
 
     stop() {
+        if (this.running) {
+            clearBuildErrors();
+        }
+
         this.running = false;
         if (this.watcherDisposable) {
             this.watcherDisposable.dispose();


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-makecode/issues/103

Also make it so when the sim window is closed it stops the build watcher / removes the listeners, instead of waiting till the next build has finished gone through & clearing then (by adding it as a disposable on the sim itself)