### PR TITLE
don't crash when initializing if no ws

### DIFF
--- a/src/web/jres.ts
+++ b/src/web/jres.ts
@@ -115,6 +115,10 @@ export async function deleteAssetAsync(node: JResTreeNode) {
 
 async function readProjectJResAsync() {
     const nodes: JResTreeNode[] = [];
+    const ws = activeWorkspace()?.uri;
+    if (!ws)
+        return [];
+
     const files = await findFilesAsync("jres", activeWorkspace().uri, false);
 
     for (const file of files) {


### PR DESCRIPTION
This feels like potentially the wrong fix, but just putting it up to see what we think; I've been seeing errors like this on occasion when reopening vscode:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'uri')
    at eval (extension.js:4:245142)
    at s.refreshJresAsync (extension.js:4:245853)
    at new s (extension.js:4:244995)
    at new t.JResTreeProvider (extension.js:4:246422)
    at t.activate (extension.js:4:238538)
    at Function.db (extHostExtensionService.ts:569:77)
    at Function.cb (extHostExtensionService.ts:558:15)
    at eval (extHostExtensionService.ts:473:43)
    at a.n (extHostExtensionActivator.ts:415:18)
    at a.m (extHostExtensionActivator.ts:410:3)
    at a.l (extHostExtensionActivator.ts:372:3)
```

it's crashing [here](https://github.com/microsoft/vscode-makecode/blob/dontCrashOnActivate/src/web/extension.ts#L85), because the constructor calls refresh which assumes `activeWorkspace()` exists ([here](https://github.com/microsoft/vscode-makecode/blob/2e31cf845f9b9e34063d0810b1ca017db69344bb/src/web/jres.ts#L118)). I think I've seen this most when using vscode.dev w/ the makecode extension directly, and I refreshed the page so file permission apis got lost.

even when it does hit that exception the commands seem to work fine afterwards which is a little surprising. Do we need to rerun `refreshWorkspaceAsync` whenever the user picks a workspace or creates a new one?