### PR TITLE
grey out simulator on runtime crash, keep to column 2

### DIFF
--- a/src/web/assetEditor.ts
+++ b/src/web/assetEditor.ts
@@ -47,7 +47,7 @@ export class AssetEditor {
         }
 
         const panel = vscode.window.createWebviewPanel(AssetEditor.viewType, vscode.l10n.t("Microsoft MakeCode Asset Editor"), {
-            viewColumn: vscode.ViewColumn.Beside,
+            viewColumn: vscode.ViewColumn.Two,
             preserveFocus: true,
         }, {
             // Enable javascript in the webview

--- a/src/web/simulator.ts
+++ b/src/web/simulator.ts
@@ -19,9 +19,6 @@ export class Simulator {
     }
 
     public static createOrShow(extCtx: vscode.ExtensionContext) {
-        let column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : vscode.ViewColumn.One;
-        column = column! < 9 ? column! + 1 : column;
-
         extensionContext = extCtx;
 
         if (Simulator.simconsole) {
@@ -40,7 +37,7 @@ export class Simulator {
         }
 
         const panel = vscode.window.createWebviewPanel(Simulator.viewType, vscode.l10n.t("Microsoft MakeCode Simulator"), {
-            viewColumn: vscode.ViewColumn.Beside,
+            viewColumn: vscode.ViewColumn.Two,
             preserveFocus: true,
         }, {
             // Enable javascript in the webview
@@ -121,6 +118,7 @@ export class Simulator {
                     }
                     Simulator.simconsole.appendLine(stackTrace);
                     Simulator.simconsole.show(false);
+                    this.stopSimulator();
                 }
         }
     }


### PR DESCRIPTION
* fix https://github.com/microsoft/vscode-makecode/issues/128; gray out simulator on runtime crash. It does already pop up the output pane 
* open in column 2 instead of always to the side; can take out if we want but if you have a text file open, then open sim, then open asset editor, splitting to a three part layout isn't a great experience unless you're on a superwide monitor. (It does still open normally / in col 1 if not editor is open)