### PR TITLE
fix HW compile; don't save base64 string as utf8

### DIFF
--- a/src/web/host.ts
+++ b/src/web/host.ts
@@ -38,7 +38,9 @@ export async function readFileAsync(path: string, encoding?: "utf8") {
 }
 
 export async function writeFileAsync(path: string, content: any, encoding?: "base64" | "utf8"): Promise<void> {
-    if (typeof content === "string") {
+    if (encoding === "base64") {
+        content = Uint8Array.from(atob(content), c => c.charCodeAt(0));
+    } else if (typeof content === "string") {
         content = new TextEncoder().encode(content);
     }
 


### PR DESCRIPTION
I tried to build for hardware and the utf8 file wouldn't flash on my meowbit and was ~33% bigger than the one I got out of `makecode f4` on the cli and looks like issue was here; we pass in a base64 encoded string but then encode it as utf8