### PR TITLE
add command to show arcade help docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,12 @@
           "light": "media/light/refresh.svg",
           "dark": "media/dark/refresh.svg"
         }
+      },
+      {
+        "command": "makecode.openHelpDocs",
+        "title": "%makecode.openHelpDocs.title%",
+        "category": "%makecode.category.title%",
+        "icon": "$(question)"
       }
     ],
     "viewsContainers": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -27,5 +27,6 @@
   "makecode.songExplorer.title": "Songs",
   "makecode.configuration.showCompileDescription": "Show a notification after compiling a MakeCode project.",
   "makecode.configuration.simWatcherDebounceDescription": "Controls the timeout in milliseconds between a file being saved and the simulator being rebuilt.",
-  "makecode.viewsWelcome.welcomeMessage": "You need to open a folder to use the MakeCode Arcade extension!\n[Open Arcade Docs](https://github.com/microsoft/vscode-makecode#microsoft-makecode-extension-for-visual-studio-code)"
+  "makecode.viewsWelcome.welcomeMessage": "You need to open a folder to use the MakeCode Arcade extension!\n[Open Arcade Docs](command:makecode.openHelpDocs)",
+  "makecode.openHelpDocs.title": "Open Arcade Docs"
 }

--- a/src/web/actionsTreeView.ts
+++ b/src/web/actionsTreeView.ts
@@ -63,6 +63,14 @@ const actions: ActionTreeNode[] = [
             command: "makecode.install"
         }
     },
+    {
+        label: vscode.l10n.t("Open Arcade Docs"),
+        icon: new vscode.ThemeIcon("question"),
+        command: {
+            title: vscode.l10n.t("Open Arcade Docs"),
+            command: "makecode.openHelpDocs"
+        }
+    }
 ]
 
 export class ActionsTreeViewProvider implements vscode.TreeDataProvider<ActionTreeNode> {

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -76,6 +76,9 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand("makecode.importUrl", importUrlCommand)
     );
     context.subscriptions.push(
+        vscode.commands.registerCommand("makecode.openHelpDocs", openHelpDocs)
+    );
+    context.subscriptions.push(
         vscode.commands.registerCommand("makecode.openAsset", uri => {
             openAssetEditor(context, uri);
         })
@@ -680,6 +683,10 @@ async function removeDependencyCommandAsync() {
         await vscode.commands.executeCommand("makecode.refreshAssets");
         await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
     })
+}
+
+function openHelpDocs() {
+    vscode.env.openExternal(vscode.Uri.parse("https://github.com/microsoft/vscode-makecode#microsoft-makecode-extension-for-visual-studio-code"));
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-makecode/issues/104

Eventually might be nice to load in the md as a virtual file and use https://github.com/microsoft/vscode/blob/main/extensions/markdown-language-features/src/commands/showPreview.ts to render it as a webview to the side (instead of popping out to a browser), but let's call that a v2