### PR TITLE
add target=arcade as default prop to tick, work around bug with other common properties

### DIFF
--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -752,9 +752,15 @@ export function tickEvent(
     properties?: { [key: string]: string },
     measurements?: { [key: string]: number }
 ) {
+    const baseProperties = {
+        "target": "arcade"
+    };
     applicationInsights?.sendTelemetryEvent(
         eventName,
-        properties,
+        {
+            ...baseProperties,
+            ...(properties || {})
+        },
         measurements
     );
 }


### PR DESCRIPTION
right now it's not including common properties like extname, extversion, vscodesessionid, etc because we're not always passing a properties bag. This makes sure we're sending one with a target=arcade prop~