### PR TITLE
don't steal focus from other tabs when simulator rebuilds automatically

### DIFF
--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -355,7 +355,6 @@ export async function simulateCommand(context: vscode.ExtensionContext) {
                 return;
             }
 
-            Simulator.createOrShow(context);
             Simulator.currentSimulator.setPanelTitle(vscode.l10n.t("Arcade Simulator"));
             Simulator.currentSimulator.simulateAsync(await readFileAsync("built/binary.js", "utf8"));
         };


### PR DESCRIPTION
This gets called already at line 378, so no reason to call it again on every automated rebuild from the watcher. As is it steals focus away from anything in that tab pane / group

fix https://github.com/microsoft/vscode-makecode/issues/144