### PR TITLE
Lazy activation for most commands, jres view

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,6 +320,10 @@
         {
           "command": "makecode.refreshAssets",
           "when": "makecode.hasMakeCodeProjectOpen"
+        },
+        {
+          "command": "makecode.testBlocks",
+          "when": "makecode.hasMakeCodeProjectOpen"
         }
       ]
     },

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -137,11 +137,11 @@ export function activate(context: vscode.ExtensionContext) {
 async function maybeSetInMakeCodeProjectAsync() {
     const hasProjectFolder = await findOpenFolders("project");
     if (!!hasProjectFolder.length) {
-        setInMakeCodeProjectAsync();
+        setInMakeCodeProject();
     }
 }
 
-export function setInMakeCodeProjectAsync() {
+export function setInMakeCodeProject() {
     vscode.commands.executeCommand("setContext", "makecode.hasMakeCodeProjectOpen", true);
 }
 
@@ -263,6 +263,7 @@ export async function installCommand() {
 
         await vscode.commands.executeCommand("makecode.refreshAssets");
         await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
+        setInMakeCodeProject();
     });
 }
 
@@ -323,7 +324,7 @@ export async function importUrlCommand(url?: string, useWorkspace?: vscode.Works
     }, async progress => {
         try {
             await downloadSharedProjectAsync(workspace!, toOpen!);
-            setInMakeCodeProjectAsync()
+            setInMakeCodeProject()
         }
         catch (e) {
             showError(vscode.l10n.t("Unable to download project"));
@@ -524,7 +525,7 @@ async function createCommand()  {
         });
     }
 
-    setInMakeCodeProjectAsync();
+    setInMakeCodeProject();
     await renameProjectAsync(workspace, projectName);
 }
 

--- a/src/web/vfs.ts
+++ b/src/web/vfs.ts
@@ -1,6 +1,6 @@
 import * as path from "path-browserify"
 import * as vscode from "vscode"
-import { importUrlCommand, setInMakeCodeProjectAsync } from "./extension";
+import { importUrlCommand, setInMakeCodeProject } from "./extension";
 
 export class VFS implements vscode.FileSystemProvider {
     private initializedDirs: {[index: string]: boolean} = {}
@@ -119,7 +119,7 @@ export class VFS implements vscode.FileSystemProvider {
         if (!(await this.existsAsync(pxtJSON))) {
             await importUrlCommand(shareId, { name: shareId, uri: projectDir, index: 0 })
         }
-        setInMakeCodeProjectAsync();
+        setInMakeCodeProject();
         this.initializedDirs[shareId] = true;
     }
 


### PR DESCRIPTION
probably can leave this one to merge in after our initial release to put in preview channel until we have more changes / things to release

* for activation command, check for nested pxt.json as well. That file is a pretty good indication it's a 'pxt focused' repo in the first place. It does appear that there's an issue with `workspaceContains` when checking top level files (`workspaceContains:./pxt.json` or `workspaceContains:/pxt.json` or `worksapceContains:pxt.json`), as it is firing off the activation event even when the folder is completely empty:
![image](https://user-images.githubusercontent.com/5615930/226070681-a30da0a7-8d81-4462-a6d1-ad818289d7dd.png)
but with `workspaceContains:**/pxt.json` it's correctly firing off only when the file is present.
* hide the asset tree views / commands that aren't help or initializing a repo until a makecode project has been loaded:
when loading empty repo:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/5615930/226081041-4d0d6340-f73c-4835-b896-d7767b702823.png">
<img width="678" alt="image" src="https://user-images.githubusercontent.com/5615930/226081125-5075a32b-aa81-409f-b3bb-0c9bccd7d44a.png">

Then after 'create a new project' or loading in a folder that contains pxt.json they'll pop in as they are now:

<img width="917" alt="image" src="https://user-images.githubusercontent.com/5615930/226081192-2fdcc0ab-7974-4115-9ea5-aeceac97b270.png">
