### PR TITLE
don't log binary js & include mkcd: protocol in mkc host

### DIFF
--- a/src/web/host.ts
+++ b/src/web/host.ts
@@ -79,7 +79,7 @@ async function unlinkAsync(path: string): Promise<void> {
 }
 
 function getFolderName() {
-    return path.basename(activeWorkspace().uri.path);
+    return `mkcd:${path.basename(activeWorkspace().uri.path)}`;
 }
 
 function rmFolderPrefix(p: string) {

--- a/src/web/host.ts
+++ b/src/web/host.ts
@@ -78,8 +78,10 @@ async function unlinkAsync(path: string): Promise<void> {
     await vscode.workspace.fs.delete(resolvePath(path));
 }
 
+// pxt-mkc only has access under the current workspace folder (see resolvePath),
+// so give an alias for that path.
 function getFolderName() {
-    return `mkcd:${path.basename(activeWorkspace().uri.path)}`;
+    return `file:${path.basename(activeWorkspace().uri.path)}`;
 }
 
 function rmFolderPrefix(p: string) {

--- a/src/web/simulator.ts
+++ b/src/web/simulator.ts
@@ -125,8 +125,6 @@ export class Simulator {
 
     postMessage(msg: any) {
         this.panel.webview.postMessage(msg);
-        msg._fromVscode = true;
-        console.log("sending", msg);
     }
 
     addDisposable(d: vscode.Disposable) {

--- a/src/web/simulator.ts
+++ b/src/web/simulator.ts
@@ -124,6 +124,7 @@ export class Simulator {
     }
 
     postMessage(msg: any) {
+        msg._fromVscode = true;
         this.panel.webview.postMessage(msg);
     }
 


### PR DESCRIPTION
* don't mirror all messages to the sim to the console (since it's printing binary js it gets trimmed almost entirely anyways)
* prefix folder names with mkcd: protocol when passing to make sure it can't match a subfolder name; I made a folder named `pxt_modules` and tried to spin up a starter project and it got mad. I couldn't tell you why I decided to try that but ¯\\_(ツ)_/¯ easy to fix