### PR TITLE
Add command for testing extension projects in the blocks editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,11 @@
         "title": "%makecode.openHelpDocs.title%",
         "category": "%makecode.category.title%",
         "icon": "$(question)"
+      },
+      {
+        "command": "makecode.testBlocks",
+        "title": "%makecode.testBlocks.title%",
+        "category": "%makecode.category.title%"
       }
     ],
     "viewsContainers": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -28,5 +28,6 @@
   "makecode.configuration.showCompileDescription": "Show a notification after compiling a MakeCode project.",
   "makecode.configuration.simWatcherDebounceDescription": "Controls the timeout in milliseconds between a file being saved and the simulator being rebuilt.",
   "makecode.viewsWelcome.welcomeMessage": "You need to open a folder to use the MakeCode Arcade extension!\n[Open Arcade Docs](command:makecode.openHelpDocs)",
-  "makecode.openHelpDocs.title": "Open Arcade Docs"
+  "makecode.openHelpDocs.title": "Open Arcade Docs",
+  "makecode.testBlocks.title": "Test extension in blocks editor"
 }

--- a/resources/editorMessaging.js
+++ b/resources/editorMessaging.js
@@ -1,0 +1,24 @@
+(function () {
+    let frame;
+    let vscode = acquireVsCodeApi();
+
+    window.addEventListener("message", function (m) {
+        if (m.data._fromVscode) {
+            frame.contentWindow.postMessage(m.data, "*");
+
+            if (m.data.type === "open") {
+                vscode.setState({
+                    editing: {
+                        assetType: m.data.assetType,
+                        assetId: m.data.assetId
+                    }
+                })
+            }
+        } else {
+            vscode.postMessage(m.data);
+        }
+    });
+    document.addEventListener("DOMContentLoaded", function (event) {
+        frame = document.getElementById("editor-frame");
+    });
+}())

--- a/resources/editorframe.html
+++ b/resources/editorframe.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MakeCode Arcade Editor</title>
+    <link href="@RES@/style.css" rel="stylesheet" type="text/css" />
+    <script src="@RES@/editorMessaging.js"></script>
+</head>
+
+<body>
+    <div id="asset-editor-container">
+        <iframe id="editor-frame" style="position:absolute;top:0;left:0;width:100%;height:100%;" src="@EDITORURL@" allowfullscreen="allowfullscreen"
+            sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0">
+        </iframe>
+    </div>
+</body>
+
+</html>

--- a/src/web/editor.ts
+++ b/src/web/editor.ts
@@ -1,0 +1,286 @@
+import * as vscode from "vscode";
+import { activeWorkspace } from "./host";
+import { debounce, getPxtJson, guidGen, readTextFileAsync } from "./util";
+
+let extensionContext: vscode.ExtensionContext;
+// const editorUrl = "http://localhost:3232/?controller=1";
+const editorUrl = "https://arcade.makecode.com/?controller=1&skillmap=1";
+
+export class MakeCodeEditor {
+    public static readonly viewType = "mkcdeditor";
+    public static currentEditor: MakeCodeEditor | undefined;
+    public simStateTimer: any;
+
+    public static createOrShow() {
+        let column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : vscode.ViewColumn.One;
+        column = column! < 9 ? column! + 1 : column;
+
+        if (MakeCodeEditor.currentEditor) {
+            MakeCodeEditor.currentEditor.panel.reveal(
+                undefined /** keep current column **/,
+                true
+            );
+            return;
+        }
+
+        const panel = vscode.window.createWebviewPanel(MakeCodeEditor.viewType, vscode.l10n.t("Microsoft MakeCode Editor"), {
+            viewColumn: vscode.ViewColumn.Two,
+            preserveFocus: true,
+        }, {
+            // Enable javascript in the webview
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+
+        MakeCodeEditor.currentEditor = new MakeCodeEditor(panel);
+    }
+
+    public static register(context: vscode.ExtensionContext) {
+        extensionContext = context;
+        vscode.window.registerWebviewPanelSerializer('mkcdeditor', new MakeCodeEditorSerializer());
+    }
+
+    public static revive(panel: vscode.WebviewPanel) {
+        MakeCodeEditor.currentEditor = new MakeCodeEditor(panel);
+    }
+
+    protected panel: vscode.WebviewPanel;
+    protected disposables: vscode.Disposable[];
+    protected pendingMessages: {[index: string]: (res: any) => void} = {};
+    protected nextId = 0;
+
+    protected running = false;
+    protected building = false;
+    protected buildPending = false;
+
+    protected watcherDisposable: vscode.Disposable | undefined;
+    protected folder: vscode.WorkspaceFolder | undefined;
+    protected currentHeaderId: string | undefined;
+
+    constructor(panel: vscode.WebviewPanel) {
+        this.panel = panel;
+
+        this.panel.webview.onDidReceiveMessage(message => {
+            this.handleEditorMessage(message);
+        });
+
+        this.panel.onDidDispose(() => {
+            if (MakeCodeEditor.currentEditor === this) {
+                MakeCodeEditor.currentEditor = undefined;
+            }
+
+            this.disposables.forEach(d => d.dispose());
+
+            this.stop();
+        });
+
+        this.disposables = [];
+
+        this.initWebviewHtmlAsync();
+    }
+
+    startWatching(folder: vscode.WorkspaceFolder) {
+        if (this.running && this.folder === folder) {return;}
+        this.stop();
+
+        this.folder = folder;
+        this.running = true;
+
+        const debounceTimer = vscode.workspace.getConfiguration().get(
+            "makecode.simulatorBuildWatcherDebounce",
+            1500
+        );
+
+        const debouncedBuild = debounce(
+            // Ideally we'd just send the project again instead of reloading the webview but because makecode aggressively
+            // caches the blocks in the toolbox we have to do a full reload.
+            () => this.initWebviewHtmlAsync(),
+            debounceTimer
+        );
+
+        const fsWatcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(folder, "**"));
+        const watchHandler = (uri: vscode.Uri) => {
+            if (!this.running) {
+                return;
+            }
+
+            // skip node_modules, pxt_modules, built, .git
+            if (/\/?((node|pxt)_modules|built|\.git)/i.test(uri.path)) {
+                return;
+            }
+            // only watch for source files
+            if (!/\.(json|jres|ts|asm|cpp|c|h|hpp)$/i.test(uri.path)) {
+                return;
+            }
+
+            debouncedBuild();
+        }
+
+        fsWatcher.onDidChange(watchHandler);
+        fsWatcher.onDidCreate(watchHandler);
+        fsWatcher.onDidDelete(watchHandler);
+        this.watcherDisposable = fsWatcher;
+        extensionContext.subscriptions.push(this.watcherDisposable);
+        this.sendProjectAsync(folder);
+    }
+
+    stop() {
+        this.running = false;
+        if (this.watcherDisposable) {
+            this.watcherDisposable.dispose();
+            this.watcherDisposable = undefined;
+        }
+    }
+
+    handleEditorMessage(message: any) {
+        if (this.pendingMessages[message.id]) {
+            this.pendingMessages[message.id](message);
+            delete this.pendingMessages[message.id];
+            return;
+        }
+
+        switch (message.type) {
+            case "pxthost":
+                this.handleHostMessage(message);
+                break;
+            case "ready":
+                this.onReadyMessageReceivedAsync();
+                break;
+        }
+    }
+
+    async handleHostMessage(message: any) {
+        if (message.action === "workspacesync") {
+            message.projects = [];
+            message._fromVscode = true;
+            this.panel.webview.postMessage(message);
+        }
+    }
+
+    async sendProjectAsync(workspace: vscode.WorkspaceFolder) {
+        const text = await createProjectBlobAsync(workspace);
+        const header = createHeader();
+        await this.sendMessageAsync({
+            type: "pxteditor",
+            action: "importproject",
+            project: {
+                header,
+                text
+            }
+        });
+    }
+
+    sendMessageAsync(message: any) {
+        message._fromVscode = true;
+        message.id = this.nextId++;
+
+        return new Promise<any>(resolve => {
+            this.pendingMessages[message.id] = resolve;
+            this.panel.webview.postMessage(message);
+        });
+    }
+
+    addDisposable(d: vscode.Disposable) {
+        this.disposables.push(d);
+    }
+
+    protected async initWebviewHtmlAsync() {
+        this.panel.webview.html = "";
+        const simulatorHTML = await getMakeCodeEditorHtmlAsync(this.panel.webview);
+        this.panel.webview.html = simulatorHTML;
+    }
+
+    protected async onReadyMessageReceivedAsync() {
+        if (!this.running) {
+            await this.startWatching(activeWorkspace());
+        }
+        else {
+            this.sendProjectAsync(this.folder || activeWorkspace());
+        }
+    }
+}
+
+export class MakeCodeEditorSerializer implements vscode.WebviewPanelSerializer {
+    async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, state: any) {
+        MakeCodeEditor.revive(webviewPanel);
+    }
+}
+
+
+async function getMakeCodeEditorHtmlAsync(webview: vscode.Webview) {
+    const uri = vscode.Uri.joinPath(extensionContext.extensionUri, "resources", "editorframe.html");
+    const contents = await readTextFileAsync(uri);
+
+    const pathURL = (s: string) =>
+        webview.asWebviewUri(vscode.Uri.joinPath(extensionContext.extensionUri, "resources", s)).toString();
+
+    return contents
+        .replace(/@RES@\/([\w\-\.]+)/g, (f, fn) => pathURL(fn))
+        .replace("@EDITORURL@", editorUrl);
+}
+
+async function createProjectBlobAsync(workspace: vscode.WorkspaceFolder) {
+    const project: {[index: string]: string} = {};
+    const config = await getPxtJson(workspace);
+
+    const processFileAsync = async (file: string) => {
+        const outFile = file === "main.ts" ? "old_main.ts" : file;
+
+        try {
+            const contents = await readTextFileAsync(vscode.Uri.joinPath(workspace.uri, file));
+            project[outFile] = contents;
+        }
+        catch (e) {
+            project[outFile] = "";
+        }
+    }
+
+    for (const file of config.files) {
+        if (file === "main.blocks") continue;
+        await processFileAsync(file);
+    }
+
+    if (config.testFiles) {
+        for (const file of config.testFiles) {
+            await processFileAsync(file);
+        }
+    }
+
+    if (!config.files.some(f => f === "main.blocks")) {
+        config.files.push("main.blocks");
+    }
+
+    if (config.files.some(f => f === "main.ts")) {
+        config.files.push("old_main.ts");
+    }
+    else {
+        config.files.push("main.ts");
+    }
+
+    config.preferredEditor = "blocksprj";
+
+    project["pxt.json"] = JSON.stringify(config);
+    project["main.blocks"] = `<xml xmlns="http://www.w3.org/1999/xhtml"><variables></variables><block type="pxt-on-start" x="0" y="0"></block></xml>`;
+    project["main.ts"] = "";
+
+    return project;
+}
+
+function createHeader() {
+    return {
+        "name": "Untitled",
+        "meta": {},
+        "editor": "blocksprj",
+        "pubId": "",
+        "pubCurrent": false,
+        "target": "arcade",
+        "targetVersion": "1.12.26",
+        "cloudUserId": null,
+        "id": guidGen(),
+        "recentUse": Date.now(),
+        "modificationTime": Date.now(),
+        "path": "Untitled",
+        "cloudCurrent": false,
+        "saveId": null
+    }
+}

--- a/src/web/util.ts
+++ b/src/web/util.ts
@@ -60,6 +60,22 @@ export async function writeTextFileAsync(uri: vscode.Uri, contents: string) {
     await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(contents));
 }
 
+export async function getPxtJson(workspace: vscode.WorkspaceFolder) {
+    const configPath = vscode.Uri.joinPath(workspace.uri, "pxt.json");
+
+    const config = await readTextFileAsync(configPath);
+    const parsed = JSON.parse(config) as pxt.PackageConfig;
+    return parsed;
+}
+
+export async function setPxtJson(workspace: vscode.WorkspaceFolder, pxtJson: pxt.PackageConfig) {
+    const configPath = vscode.Uri.joinPath(workspace.uri, "pxt.json");
+    await writeTextFileAsync(
+        configPath,
+        JSON.stringify(pxtJson, null, 4)
+    );
+}
+
 
 function getRandomBuf(buf: Uint8Array) {
     if (crypto)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-makecode/issues/85

This PR adds a command for opening another project in the blocks editor that has the current project as a dependency. In other words, it works the same as the "test extension" button in MakeCode's GitHub editor, but with file watching and auto-reload. This new command can only be accessed by typing in the command palette since it's a sorta advanced scenario.

The test block project is persisted locally in the `.pxt` folder so that you don't lose your test programs in between runs. There is currently no way to clear that project other than manually deleting `.pxt/test_project`, but i don't think that's such a problem. You can always just delete all the blocks and start over!