### PR TITLE
add a 'preview tutorial' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,11 @@
         "command": "makecode.testBlocks",
         "title": "%makecode.testBlocks.title%",
         "category": "%makecode.category.title%"
+      },
+      {
+        "command": "makecode.testTutorial",
+        "title": "%makecode.testTutorial.title%",
+        "category": "%makecode.category.title%"
       }
     ],
     "viewsContainers": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -29,5 +29,6 @@
   "makecode.configuration.simWatcherDebounceDescription": "Controls the timeout in milliseconds between a file being saved and the simulator being rebuilt.",
   "makecode.viewsWelcome.welcomeMessage": "You need to open a folder to use the MakeCode Arcade extension!\n[Open Arcade Docs](command:makecode.openHelpDocs)",
   "makecode.openHelpDocs.title": "Open Arcade Docs",
-  "makecode.testBlocks.title": "Test extension in blocks editor"
+  "makecode.testBlocks.title": "Test Extension in Blocks Editor",
+  "makecode.testTutorial.title": "Preview Tutorial in Blocks Editor"
 }


### PR DESCRIPTION
Add a 'preview tutorial in blocks editor' command to preview tutorials similar to https://makecode.com/tutorial-tool

Do we know if there's any way to set state for the webview directly from `src/web/editor.ts`? Ideally we should be persisting / reloading that `tutorialUri` from the state in `MakeCodeEditorSerializer` but I didn't see an obvious way to do that; is it just adding another message in `resources/editorMessaging` similar to the "open" one that sends in the tutorial uri and then doesn't propagate it to the editor frame??

I poked around for a minute to see about making it load in the current project as an extension, but it appeared to get dropped at some point in the tutorial load process and I didn't want to go down that rabbit hole for now. Here's the very quick branch as a ref https://github.com/microsoft/pxt/tree/allowLoadingHeaderForTutorialPreview. FWIW it looks like the github integration feature is broken as well https://github.com/microsoft/pxt-microbit/issues/4777.

Maybe more importantly, it's a weird inconsistency we should probably think on -- if you load a tutorial from a github project it auto adds itself as a dependency (without declaring it in package.json), but it doesn't do the same thing if you load from a share link. I'd probably lean towards share link behavior of no magic imports personally (which this handles :))
