### PR TITLE
Update CDN URL

### DIFF
--- a/src/web/makecodeGallery.ts
+++ b/src/web/makecodeGallery.ts
@@ -4,7 +4,7 @@ import { httpRequestCoreAsync } from "./host";
 import { listHardwareVariantsAsync } from "./makecodeOperations";
 import { readTextFileAsync } from "./util";
 
-const apiRoot = "https://pxt.azureedge.net";
+const apiRoot = "https://cdn.makecode.com";
 
 const disallowedHardwareVariants = [
     "Arcade table",


### PR DESCRIPTION
<s>Not tested yet so don't check it in ;)</s>

Tested locally that we can hit new cdn and get project templates & hardware options:
![image](https://github.com/user-attachments/assets/966043a7-0998-47e7-96bb-1629cd0ecb31)

![image](https://github.com/user-attachments/assets/ee050466-ed62-4f19-aec7-cd7ed7263e2b)

