### PR TITLE
Bump version again for release (1.0.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "ms-edu",
   "displayName": "Microsoft MakeCode Arcade",
   "description": "Make games and learn code. Create retro arcade style video games, art, and music inside VS Code.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "engines": {
     "vscode": "^1.75.0"
   },


### PR DESCRIPTION
It has to be different from the version we sent to pre-release, apparently. See https://code.visualstudio.com/api/working-with-extensions/publishing-extension#:~:text=We%20only%20support,in%20the%20future.